### PR TITLE
Prevent bar from appearing when starting in landscape and rotating to portrait

### DIFF
--- a/MessageBar.js
+++ b/MessageBar.js
@@ -30,6 +30,16 @@ class MessageBar extends Component {
     this.state = this.getStateByProps(props)
   }
 
+  componentDidMount() {
+    // Configure the offsets prior to recieving updated props or recieving the first alert
+    // This ensures the offsets are set properly at the outset based on the initial position.
+    // This prevents the bar from appearing  and covering half of the screen when the
+    // device is started in landscape and then rotated to portrait.
+    // This does not happen after the first alert appears, as setNewState() is called on each
+    // alert and calls _changeOffsetByPosition()
+    this._changeOffsetByPosition(this.state.position);
+  }
+
   componentWillReceiveProps (nextProps) {
     if (nextProps && Object.keys(nextProps).length > 0) {
       this.setNewState(nextProps)

--- a/MessageBar.js
+++ b/MessageBar.js
@@ -30,14 +30,14 @@ class MessageBar extends Component {
     this.state = this.getStateByProps(props)
   }
 
-  componentDidMount() {
+  componentDidMount () {
     // Configure the offsets prior to recieving updated props or recieving the first alert
     // This ensures the offsets are set properly at the outset based on the initial position.
     // This prevents the bar from appearing  and covering half of the screen when the
     // device is started in landscape and then rotated to portrait.
     // This does not happen after the first alert appears, as setNewState() is called on each
     // alert and calls _changeOffsetByPosition()
-    this._changeOffsetByPosition(this.state.position);
+    this._changeOffsetByPosition(this.state.position)
   }
 
   componentWillReceiveProps (nextProps) {


### PR DESCRIPTION
When starting the app with the device in landscape mode and then rotating to portrait, the MessageBar appears and takes up half the screen (I didn't even suspect this was the MessageBar until I opened the element inspector). This does not happen if you start in landscape, make a message appear, and then rotate- it only happens if no messages appear.

It appears that the appropriate offsets were not set to null based on the position until setNewState() was called, which (usually) happens on the first message. Therefore, all offsets changed by _changeOffsetByPosition() were initially set by zero. I'm not entirely sure why this does what it does, but it was the one difference I could identify between before-first-message and after-first-message, and it seems to fix this issue.