### PR TITLE
Enable setting default per-component values.

### DIFF
--- a/MessageBar.js
+++ b/MessageBar.js
@@ -28,6 +28,7 @@ class MessageBar extends Component {
     this.timeoutHide = null
 
     this.state = this.getStateByProps(props)
+    this.defaultState = this.getStateByProps(props)
   }
 
   componentDidMount () {
@@ -58,10 +59,13 @@ class MessageBar extends Component {
   }
 
   getStateByProps (props) {
+    const def = this.defaultState || {}
     return {
       // Default values, will be overridden
       backgroundColor: '#007bff', // default value : blue
       strokeColor: '#006acd', // default value : blue
+      titleColor: '#ffffff', // default value : white
+      messageColor: '#ffffff', // default value : white
       animationTypeTransform: 'SlideFromTop', // default value
 
       /* Cusomisation of the alert: Title, Message, Icon URL, Alert alertType (error, success, warning, info), Duration for Alert keep shown */
@@ -69,86 +73,110 @@ class MessageBar extends Component {
       message: props.message,
       avatar: props.avatar,
       alertType: props.alertType || 'info',
-      duration: props.duration || 3000,
+      duration: props.duration || def.duration || 3000,
 
       /* Hide setters */
-      shouldHideAfterDelay: props.shouldHideAfterDelay == undefined
-        ? true
-        : props.shouldHideAfterDelay,
-      shouldHideOnTap: props.shouldHideOnTap == undefined
-        ? true
-        : props.shouldHideOnTap,
+      shouldHideAfterDelay:
+        props.shouldHideAfterDelay == undefined &&
+        def.shouldHideAfterDelay == undefined
+          ? true
+          : props.shouldHideAfterDelay || def.shouldHideAfterDelay,
+      shouldHideOnTap:
+        props.shouldHideOnTap == undefined &&
+        def.shouldHideOnTap == undefined
+          ? true
+          : props.shouldHideOnTap || def.shouldHideOnTap,
 
       /* Callbacks method on Alert Tapped, on Alert Show, on Alert Hide */
-      onTapped: props.onTapped,
-      onShow: props.onShow,
-      onHide: props.onHide,
+      onTapped: props.onTapped || def.onTapped,
+      onShow: props.onShow || def.onShow,
+      onHide: props.onHide || def.onHide,
 
       /* Stylesheets */
-      stylesheetInfo: props.stylesheetInfo || {
+      stylesheetInfo: props.stylesheetInfo ||
+      def.stylesheetInfo || {
         backgroundColor: '#007bff',
-        strokeColor: '#006acd'
+        strokeColor: '#006acd',
+        titleColor: '#ffffff',
+        messageColor: '#ffffff'
       }, // Default are blue colors
-      stylesheetSuccess: props.stylesheetSuccess || {
+      stylesheetSuccess: props.stylesheetSuccess ||
+      def.stylesheetSuccess || {
         backgroundColor: 'darkgreen',
-        strokeColor: 'darkgreen'
+        strokeColor: 'darkgreen',
+        titleColor: '#ffffff',
+        messageColor: '#ffffff'
       }, // Default are Green colors
-      stylesheetWarning: props.stylesheetWarning || {
+      stylesheetWarning: props.stylesheetWarning ||
+      def.stylesheetWarning || {
         backgroundColor: '#ff9c00',
-        strokeColor: '#f29400'
+        strokeColor: '#f29400',
+        titleColor: '#ffffff',
+        messageColor: '#ffffff'
       }, // Default are orange colors
-      stylesheetError: props.stylesheetError || {
+      stylesheetError: props.stylesheetError ||
+      def.stylesheetError || {
         backgroundColor: '#ff3232',
-        strokeColor: '#FF0000'
+        strokeColor: '#FF0000',
+        titleColor: '#ffffff',
+        messageColor: '#ffffff'
       }, // Default are red colors
-      stylesheetExtra: props.stylesheetExtra || {
+      stylesheetExtra: props.stylesheetExtra ||
+      def.stylesheetExtra || {
         backgroundColor: '#007bff',
-        strokeColor: '#006acd'
+        strokeColor: '#006acd',
+        titleColor: '#ffffff',
+        messageColor: '#ffffff'
       }, // Default are blue colors, same as info
 
       /* Duration of the animation */
-      durationToShow: props.durationToShow || 350,
-      durationToHide: props.durationToHide || 350,
+      durationToShow: props.durationToShow || def.durationToShow || 350,
+      durationToHide: props.durationToHide || def.durationToHide || 350,
 
       /* Offset of the View, useful if you have a navigation bar or if you want the alert be shown below another component instead of the top of the screen */
-      viewTopOffset: props.viewTopOffset || 0,
-      viewBottomOffset: props.viewBottomOffset || 0,
-      viewLeftOffset: props.viewLeftOffset || 0,
-      viewRightOffset: props.viewRightOffset || 0,
+      viewTopOffset: props.viewTopOffset || def.viewTopOffset || 0,
+      viewBottomOffset: props.viewBottomOffset || def.viewBottomOffset || 0,
+      viewLeftOffset: props.viewLeftOffset || def.viewLeftOffset || 0,
+      viewRightOffset: props.viewRightOffset || def.viewRightOffset || 0,
 
       /* Inset of the view, useful if you want to apply a padding at your alert content */
-      viewTopInset: props.viewTopInset || 0,
-      viewBottomInset: props.viewBottomInset || 0,
-      viewLeftInset: props.viewLeftInset || 0,
-      viewRightInset: props.viewRightInset || 0,
+      viewTopInset: props.viewTopInset || def.viewTopInset || 0,
+      viewBottomInset: props.viewBottomInset || def.viewBottomInset || 0,
+      viewLeftInset: props.viewLeftInset || def.viewLeftInset || 0,
+      viewRightInset: props.viewRightInset || def.viewRightInset || 0,
 
       /* Padding around the content, useful if you want a tiny message bar */
-      messageBarPadding: props.messageBarPadding || 10,
+      messageBarPadding: props.messageBarPadding || def.messageBarPadding || 10,
 
       /* Number of Lines for Title and Message */
-      titleNumberOfLines: props.titleNumberOfLines == undefined
-        ? 1
-        : props.titleNumberOfLines,
-      messageNumberOfLines: props.messageNumberOfLines == undefined
-        ? 2
-        : props.messageNumberOfLines,
+      titleNumberOfLines:
+        props.titleNumberOfLines == undefined &&
+        def.titleNumberOfLines == undefined
+          ? 1
+          : props.titleNumberOfLines || def.titleNumberOfLines,
+      messageNumberOfLines:
+        props.messageNumberOfLines == undefined &&
+        def.titleNumberOfLines == undefined
+          ? 2
+          : props.messageNumberOfLines || def.messageNumberOfLines,
 
       /* Style for the text elements and the avatar */
-      titleStyle: props.titleStyle || {
-        color: 'white',
+      titleStyle: props.titleStyle || def.titleStyle || {
         fontSize: 18,
         fontWeight: 'bold'
       },
-      messageStyle: props.messageStyle || { color: 'white', fontSize: 16 },
-      avatarStyle: props.avatarStyle || {
+      messageStyle: props.messageStyle || def.messageStyle || {
+        fontSize: 16
+      },
+      avatarStyle: props.avatarStyle || def.avatarStyle || {
         height: 40,
         width: 40,
         borderRadius: 20
       },
 
       /* Position of the alert and Animation Type the alert is shown */
-      position: props.position || 'top',
-      animationType: props.animationType
+      position: props.position || def.position || 'top',
+      animationType: props.animationType || def.animationType
     }
   }
 
@@ -277,33 +305,47 @@ class MessageBar extends Component {
 
     let backgroundColor
     let strokeColor
+    let titleColor
+    let messageColor
 
     switch (alertType) {
       case 'success':
         backgroundColor = this.state.stylesheetSuccess.backgroundColor
         strokeColor = this.state.stylesheetSuccess.strokeColor
+        titleColor = this.state.stylesheetSuccess.titleColor
+        messageColor = this.state.stylesheetSuccess.messageColor
         break
       case 'error':
         backgroundColor = this.state.stylesheetError.backgroundColor
         strokeColor = this.state.stylesheetError.strokeColor
+        titleColor = this.state.stylesheetError.titleColor
+        messageColor = this.state.stylesheetError.messageColor
         break
       case 'warning':
         backgroundColor = this.state.stylesheetWarning.backgroundColor
         strokeColor = this.state.stylesheetWarning.strokeColor
+        titleColor = this.state.stylesheetWarning.titleColor
+        messageColor = this.state.stylesheetWarning.messageColor
         break
       case 'info':
         backgroundColor = this.state.stylesheetInfo.backgroundColor
         strokeColor = this.state.stylesheetInfo.strokeColor
+        titleColor = this.state.stylesheetInfo.titleColor
+        messageColor = this.state.stylesheetInfo.messageColor
         break
       default:
         backgroundColor = this.state.stylesheetExtra.backgroundColor
         strokeColor = this.state.stylesheetExtra.strokeColor
+        titleColor = this.state.stylesheetExtra.titleColor
+        messageColor = this.state.stylesheetExtra.messageColor
         break
     }
 
     this.setState({
       backgroundColor: backgroundColor,
-      strokeColor: strokeColor
+      strokeColor: strokeColor,
+      titleColor: titleColor,
+      messageColor: messageColor
     })
   }
 
@@ -467,7 +509,7 @@ class MessageBar extends Component {
       return (
         <Text
           numberOfLines={this.state.titleNumberOfLines}
-          style={this.state.titleStyle}>
+          style={[this.state.titleStyle, {color: this.state.titleColor}]}>
           {this.state.title}
         </Text>
       )
@@ -479,7 +521,7 @@ class MessageBar extends Component {
       return (
         <Text
           numberOfLines={this.state.messageNumberOfLines}
-          style={this.state.messageStyle}>
+          style={[this.state.messageStyle, {color: this.state.messageColor}]}>
           {this.state.message}
         </Text>
       )

--- a/README.md
+++ b/README.md
@@ -127,11 +127,16 @@ MessageBarManager.showAlert({
   alertType: 'info', // Alert Type: you can select one of 'success', 'error', 'warning', 'error', or 'custom' (use custom if you use a 5th stylesheet, all are customizable). Default is 'info'
 
   /* Customize the stylesheets and/or provide an additional one 'extra' */
-  stylesheetInfo : {{ backgroundColor : '#007bff', strokeColor : '#006acd' }}, // Default are blue colors
-  stylesheetSuccess : {{ backgroundColor : 'darkgreen', strokeColor : '#b40000' }}, // Default are Green colors
-  stylesheetWarning : {{ backgroundColor : '#ff9c00', strokeColor : '#f29400' }}, // Default are orange colors
-  stylesheetError : {{ backgroundColor : '#ff3232', strokeColor : '#FF0000' }}, // Default are red colors
-  stylesheetExtra : {{ backgroundColor : 'black', strokeColor : 'gray' }}, // Default are blue colors, same as info
+  stylesheetInfo : {{ backgroundColor : '#007bff', strokeColor : '#006acd',
+                      titleColor: '#ffffff', messageColor: '#ffffff' }}, // Default are blue colors with white title and message
+  stylesheetSuccess : {{ backgroundColor : 'darkgreen', strokeColor : '#b40000',
+                         titleColor: '#ffffff', messageColor: '#ffffff' }}, // Default are Green colors with white title and message
+  stylesheetWarning : {{ backgroundColor : '#ff9c00', strokeColor : '#f29400',
+                         titleColor: '#ffffff', messageColor: '#ffffff' }}, // Default are orange colors with white title and message
+  stylesheetError : {{ backgroundColor : '#ff3232', strokeColor : '#FF0000',
+                         titleColor: '#ffffff', messageColor: '#ffffff' }}, // Default are red colors with white title and message
+  stylesheetExtra : {{ backgroundColor : 'black', strokeColor : 'gray',
+                         titleColor: '#ffffff', messageColor: '#ffffff' }}, // Default are blue colors with white title and message, same as info
 
   ...
 });
@@ -199,6 +204,32 @@ MessageBarManager.showAlert({
 ```
 
 
+## Setting default values for an alert reference
+Default values (for style etc.) can be set when `MessageBarAlert` is added to your render function e.g.:
+```javascript
+<MessageBarAlert
+  ref="alert"
+  titleStyle={{
+    fontSize: 36,
+    fontWeight: 'bold'
+  }}
+  messageStyle={{
+    fontSize: 28
+  }}
+  duration={6000}
+  viewTopOffset={10}
+  stylesheetSuccess={{
+    backgroundColor: '#52d80f',
+    strokeColor: '#43c90e',
+    titleColor: '#ffffff',
+    messageColor: '#ffffff'
+  }}
+/>
+```
+These values override the built-in default values and hold for all `MessageBarManager.showAlert()` calls on the same reference.
+All properties except `title`, `message`, `avatar`, and `alertType` can be set in render.
+
+
 ## Properties
 Prop                  | Type     | Default              | Description
 --------------------- | -------- | -------------------- | -----------
@@ -206,7 +237,7 @@ title                 | String   |                      | Title of the alert
 message               | String   |                      | Message of the alert
 avatar                | String   |                      | Avatar/Icon source/URL of the alert. Use <URL> for a remote image file (eg `avatar: 'http://mywebsite.com/myimage.jpg'`) or use `avatar: require('<path/to/my/local/image.extension>')` for a remote image file
 alertType             | String   | info                 | Alert Type: you can select one of 'success', 'error', 'warning', 'error', or 'custom' (use custom if you use a 5th stylesheet, all are customizable).
-duration              | Number   | 3000                 | Number of ms the alert is displayed  
+duration              | Number   | 3000                 | Number of ms the alert is displayed
 shouldHideAfterDelay  | Bool     | true                 | Tell the MessageBar whether or not it should hide after a delay defined in the `duration` property. If `false`, the MessageBar remain shown
 shouldHideOnTap       | Bool     | true                 | Tell the MessageBar whether or not it should hide or not when the user tap the alert. If `false`, the MessageBar will not hide, but the `onTapped` function is triggered, if defined. In addition, if `false`, the `onHide` function will not be triggered. The property `shouldHideAfterDelay` take precedence over `shouldHideOnTap`. That means if `shouldHideAfterDelay` is `false`, the value of `shouldHideOnTap` is not taken into account, since the MessageBar will not ever be hidden
 onTapped              | Function |                      | Callback function after alert is tapped


### PR DESCRIPTION
If style or other params are different to default values and valid for same component, they can be set for all `showAlert` calls, e.g.
```
<MessageBar
  ref="alert"
  duration={6000}
  viewTopOffset={10}
  stylesheetSuccess={{
    backgroundColor: '#52d80f',
    strokeColor: '#43c90e',
    titleColor: '#ffffff',
    messageColor: '#ffffff'
  }}
```