### PR TITLE
fix(react): react 17 support

### DIFF
--- a/MessageBar.js
+++ b/MessageBar.js
@@ -41,7 +41,7 @@ class MessageBar extends Component {
     this._changeOffsetByPosition(this.state.position)
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     if (nextProps && Object.keys(nextProps).length > 0) {
       this.setNewState(nextProps)
     }


### PR DESCRIPTION
Thank you for this library!

## What's the change?

- Added UNSAFE to componentWillReceiveProps so that `MessageBar` will work in React 17.x

### Fixes

#41 

### Aside

If necessary, more than happy to convert this library to a function component with hooks. 